### PR TITLE
Fixes and additions to the modal on the collections page

### DIFF
--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -239,7 +239,6 @@ export const Avatar = ({ address }: { address: string }) => {
             display="flex"
             alignItems="center"
             justifyContent="center"
-            padding="10px"
             cursor="pointer"
             mb="4"
           >


### PR DESCRIPTION
# Overview

All mentions of the current network are linked to environment variables, made all links on collectible details page working, added working description to NFTs, changed styling of modal(removed black background, made images responsive). NFT cards now open correctly, no more empty cards, only shows owned NFTs.

# Tickets

N/A

# Screenshots

**Before**
![before](https://github.com/trilitech/astro-ninja/assets/89266106/ed5374a5-f65d-4a39-be02-dde01925a8b6)

**After**
![after](https://github.com/trilitech/astro-ninja/assets/89266106/bf85fb04-016c-47e8-8e1c-94f2d8b3602d)

# Testing

Tested on iPhoneSE, iPhone XR, Pixel 5, iPad Mini and desktop screen sizes with no visual glitches, I tested the functionality of NFT cards with no errors this time either.