### PR TITLE
Fixed Margin Below Dropdown

### DIFF
--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -171,7 +171,6 @@ export const Avatar = ({ address }: { address: string }) => {
               justifyContent="center"
               onClick={toggleDropdown}
               cursor="pointer"
-              mb="4"
             >
               <span>{address.substring(0, 3) + ".." + address.slice(-5)}</span>
               <Box marginLeft="5px">
@@ -224,11 +223,10 @@ export const Avatar = ({ address }: { address: string }) => {
 
           <Flex flexWrap="wrap"></Flex>
           <Box
-            marginTop="15px"
+            mt="4"
+            mb="4"
             width="80%"
             borderBottom="1px solid #DBDBDB"
-            margin="auto"
-            marginBottom="25px"
             position="relative"
           ></Box>
           <MenuItem


### PR DESCRIPTION
# Overview

Fixed unnecessary bottom margin on dropdown menu for profile.

# Tickets

- [fix dropdown gap](https://app.asana.com/0/1205185701134472/1205302674481541/f)

# Screenshots

**Before**
![before](https://github.com/trilitech/astro-ninja/assets/89266106/09f03eda-8aec-43d5-b113-fe46b3369f5d)

**After**
![after](https://github.com/trilitech/astro-ninja/assets/89266106/7b2dd1d3-4c4d-49b3-aec4-64729a53953c)

# Testing
Tested using all screen sizes on Google Chrome Developer Console and all worked as expected, no visual bugs or glitches or otherwise.
